### PR TITLE
Fix query string parsing

### DIFF
--- a/src/query-parser.js
+++ b/src/query-parser.js
@@ -1,4 +1,3 @@
-var url = require( 'url' );
 var rethinkdb = require( 'rethinkdb' );
 
 
@@ -76,7 +75,7 @@ QueryParser.prototype.parseInput = function( input ) {
 		return this._queryError( input, 'Missing ?' );
 	}
 
-	search = url.parse( input ).query;
+	search = input.substring( input.indexOf( '?' ) + 1 );
 
 	try{
 		parsedInput = JSON.parse( search );

--- a/src/query-parser.js
+++ b/src/query-parser.js
@@ -1,3 +1,4 @@
+var url = require( 'url' );
 var rethinkdb = require( 'rethinkdb' );
 
 
@@ -23,7 +24,7 @@ var QueryParser = function( provider ) {
  * "ne" (not equal)
  *
  * @todo  Support for OR might come in handy
- * 
+ *
  * @param   {String} name The recordName for the list, including search parameters
  *
  * @public
@@ -63,18 +64,19 @@ QueryParser.prototype.createQuery = function( parsedInput ) {
  * @returns {Object) parsedInput
  */
 QueryParser.prototype.parseInput = function( input ) {
-	
+
 	var operators = [ 'eq', 'match', 'gt', 'lt', 'ne'],
 		search,
 		parsedInput,
 		condition,
 		i;
 
+
 	if( input.indexOf( '?' ) === -1 ) {
 		return this._queryError( input, 'Missing ?' );
 	}
 
-	search = input.split( '?' )[ 1 ];
+	search = url.parse( input ).query;
 
 	try{
 		parsedInput = JSON.parse( search );

--- a/src/search.js
+++ b/src/search.js
@@ -3,7 +3,7 @@ var r = require( 'rethinkdb' ),
 
 /**
  * This class represents a single realtime search query against RethinkDb.
- * 
+ *
  * It creates two cursors, one to
  * retrieve the initial matches, one to listen for incoming changes. It then
  * creates a deepstream list and populates it with the changes
@@ -51,12 +51,16 @@ var Search = function( provider, query, listName, rethinkdbConnection, deepstrea
  * @returns {void}
  */
 Search.prototype.destroy = function( deleteList ) {
+	if( !this._list ) {
+		return;
+	}
+	
 	this._provider.log( 'Removing search ' + this._list.name );
 
 	if( deleteList ) {
 		this._list.delete();
 	}
-	
+
 	this._changeFeedCursor.close();
 	this._changeFeedCursor = null;
 	this._list = null;

--- a/src/search.js
+++ b/src/search.js
@@ -54,15 +54,18 @@ Search.prototype.destroy = function( deleteList ) {
 	if( !this._list ) {
 		return;
 	}
-	
+
 	this._provider.log( 'Removing search ' + this._list.name );
 
 	if( deleteList ) {
 		this._list.delete();
 	}
 
-	this._changeFeedCursor.close();
-	this._changeFeedCursor = null;
+	if( this._changeFeedCursor ) {
+		this._changeFeedCursor.close();
+		this._changeFeedCursor = null;
+	}
+	
 	this._list = null;
 	this._rethinkdbConnection = null;
 	this._deepstreamClient = null;


### PR DESCRIPTION
This fixes the problem where the search query has a `?` character. For example:

```
search?{"table":"user","query":[["username","match","(?i)^username$"]]}
```
