### PR TITLE
Order limit - implements #1

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -45,7 +45,7 @@ var Search = function( provider, query, listName, rethinkdbConnection, deepstrea
 Search.prototype.destroy = function() {
 
   if( this._list ) {
-    this._provider.log( 'Removing search ' + this._list.name )
+    this._provider.log( 'Removing search ' + this._list.name, 2 )
     this._list.delete()
     this._list = null
   }

--- a/test/query-parseSpec.js
+++ b/test/query-parseSpec.js
@@ -7,34 +7,31 @@ const QueryParser = require( '../src/query-parser' )
 const log = sinon.spy()
 const queryParser = new QueryParser({ log: (log) })
 
-describe( 'queries are parsed correctly', () => {
+describe( 'the query parser', () => {
 
   it( 'parses queries with a single condition correctly', () => {
-    var parsedInput = queryParser.parseInput( 'search?{"table":"books","query":[["name","eq","Harry Potter"]]}' )
-
-    expect( parsedInput ).to.deep.equal({
+    var query = {
       table: 'books',
       query: [[ 'name', 'eq', 'Harry Potter' ]]
-    })
+    }
+    var parsedInput = queryParser.parseInput( 'search?' + JSON.stringify(query) )
 
+    expect( parsedInput ).to.deep.equal( query )
     expect( log ).to.have.not.been.called
   })
 
   it( 'parses queries with multiple conditions correctly', () => {
-    var parsedInput = queryParser.parseInput(
-      `search?{"table":"books",
-      "query":[["name","eq","Harry Potter"],["price","gt",12.3],["publisher","match",".*random.*"]]}`
-    )
-
-    expect( parsedInput ).to.deep.equal({
+    var query = {
       table: 'books',
       query: [
         [ 'name', 'eq', 'Harry Potter' ],
         [ 'price', 'gt', 12.3 ],
         [ 'publisher', 'match', '.*random.*' ]
       ]
-    })
+    }
+    var parsedInput = queryParser.parseInput( 'search?' + JSON.stringify(query) )
 
+    expect( parsedInput ).to.deep.equal( query )
     expect( log ).to.have.not.been.called
   })
 
@@ -60,6 +57,18 @@ describe( 'queries are parsed correctly', () => {
     var parsedInput = queryParser.parseInput( 'search?{"table":"books"}' )
     expect( parsedInput ).to.equal( null )
     expect( log ).to.have.been.calledWith( 'QUERY ERROR | Missing parameter "query"', 1 )
+  })
+
+  it( 'errors for order without limit', () => {
+    var parsedInput = queryParser.parseInput( 'search?{"table":"books","query":[],"order":"price"}' )
+    expect( parsedInput ).to.equal( null )
+    expect( log ).to.have.been.calledWith( 'QUERY ERROR | Must specify both "order" and "limit" together', 1 )
+  })
+
+  it( 'errors for limit without order', () => {
+    var parsedInput = queryParser.parseInput( 'search?{"table":"books","query":[],"limit":1}' )
+    expect( parsedInput ).to.equal( null )
+    expect( log ).to.have.been.calledWith( 'QUERY ERROR | Must specify both "order" and "limit" together', 1 )
   })
 
   it( 'errors for malformed query', () => {

--- a/test/tools/create-test-table.js
+++ b/test/tools/create-test-table.js
@@ -36,13 +36,17 @@ var createTable = function() {
 
 var populateTable = function( error ) {
 	r.table( connectionParams.testTable ).insert([
-		{ ds_id: 'don', __ds: { _v: 1 }, title: 'Don Quixote', author:	'Miguel de Cervantes', language: 'Spanish', released: 1605, copiesSold: 315000000 },
+		{ ds_id: 'don', __ds: { _v: 1 }, title: 'Don Quixote', author: 'Miguel de Cervantes', language: 'Spanish', released: 1605, copiesSold: 315000000 },
 		{ ds_id: 'tct', __ds: { _v: 1 }, title: 'A Tale Of Two Cities', author: 'Charles Dickens', language: 'English', released: 1859, copiesSold: 200000000 },
 		{ ds_id: 'lor', __ds: { _v: 1 }, title: 'The Lord of the Rings', author: 'J. R. R. Tolkien', language: 'English', released: 1954, copiesSold: 150000000 },
 		{ ds_id: 'tlp', __ds: { _v: 1 }, title: 'The Little Prince', author: 'Antoine de Saint-Exupéry', language: 'French', released: 1943, copiesSold: 140000000 },
 		{ ds_id: 'hrp', __ds: { _v: 1 }, title: 'Harry Potter and the Philosopher\'s Stone', author: 'J. K. Rowling', language: 'English', released: 1997, copiesSold: 107000000 }
-	]).run( connection, fn( complete ) );
+	]).run( connection, fn( addIndex ) );
 };
+
+var addIndex = function( error ) {
+  r.table( connectionParams.testTable ).indexCreate( 'released' ).run( connection, fn( complete ) )
+}
 
 var complete = function() {
 	connection.close();

--- a/test/tools/test-helper.js
+++ b/test/tools/test-helper.js
@@ -40,8 +40,9 @@ exports.connectToDeepstream = function( done ) {
 };
 
 exports.cleanUp = function( provider, deepstream, done ) {
-	provider.stop();
+	// FIXME: this is to wait for an unsubscription ACK - remove timeout when DS closes cleanly
 	setTimeout( () => {
+		provider.stop();
 		deepstream.close();
 		done();
 	}, 100 );


### PR DESCRIPTION
Changefeeds with `orderBy` require `limit`, and with `limit` require `orderBy`, see https://rethinkdb.com/docs/changefeeds/javascript/ ("`orderBy` requires `limit`; neither command works by itself."). Since we required a search which returned only the most recent of something, we have implemented it.
