### PR TITLE
Fixes #57

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -90,6 +90,10 @@ Search.prototype._onChange = function( error, cursor ) {
  * @returns {void}
  */
 Search.prototype._readChange = function( cursorError, change ) {
+  // Search.prototype.destroy has already been called, cursor already closed
+  if( !this._list )
+    return false;
+
   if( cursorError ) {
     this._onError( 'cursor error on change: ' + cursorError.toString() )
   }


### PR DESCRIPTION
[`cursor.each` is called lazily](https://rethinkdb.com/api/javascript/each/), which means we have a race condition between `destroy` and `_onChange`. To resolve that, test if `destroy` has already run, then give up early processing the change list.